### PR TITLE
Fix browser crash on login attempt

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -3,6 +3,22 @@ import { useQuery } from "@tanstack/react-query";
 export function useAuth() {
   const { data: user, isLoading } = useQuery({
     queryKey: ["/api/auth/user"],
+    queryFn: async () => {
+      const res = await fetch("/api/auth/user", {
+        credentials: "include",
+      });
+      
+      // Return null for 401 (unauthenticated) instead of throwing
+      if (res.status === 401) {
+        return null;
+      }
+      
+      if (!res.ok) {
+        throw new Error(`${res.status}: ${res.statusText}`);
+      }
+      
+      return await res.json();
+    },
     retry: false,
   });
 


### PR DESCRIPTION
- Add missing queryFn to useAuth hook
- Handle 401 responses gracefully instead of throwing
- Prevent browser crashes for unauthenticated users
- Maintain proper error handling for other HTTP errors